### PR TITLE
Update installers version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require": {
     "php": ">=5.6",
-    "composer/installers": "~1.2.0"
+    "composer/installers": "^1.4"
   },
   "extra" : {
     "installer-name": "dw-document-revisions"


### PR DESCRIPTION
Bring it in line with current bedrock to stop the wp/bedrock update
on intranet from breaking.